### PR TITLE
Client Role added to TCPServer

### DIFF
--- a/com.ibm.streamsx.tcp/impl/Makefile
+++ b/com.ibm.streamsx.tcp/impl/Makefile
@@ -10,8 +10,8 @@ CXXFLAGS=-O3 -DNDEBUG -fPIC
 
 .PHONY: clean distclean
 
-all: lib/libstreams.spl.multiconnection.tcp.server.so
-
+all: lib/libstreams.spl.multiconnection.tcp.server.so 
+	
 lib/socket.o: src/mcts/socket.cpp include/mcts/socket.h 
 	mkdir   -p    ./lib
 	@echo Compiling 'src/mcts/socket.cpp' ...

--- a/com.ibm.streamsx.tcp/impl/include/mcts/connection.h
+++ b/com.ibm.streamsx.tcp/impl/include/mcts/connection.h
@@ -98,9 +98,6 @@ namespace mcts
         // Blocksize
         uint32_t blockSize_;
 
-        // Prepended message size header
-        bool messageHeader_;
-
         // output format
         outFormat_t outFormat_;
 

--- a/com.ibm.streamsx.tcp/impl/include/mcts/connection.h
+++ b/com.ibm.streamsx.tcp/impl/include/mcts/connection.h
@@ -39,7 +39,9 @@ namespace mcts
         /// @param ioService the IO service
         /// @param handler the handler
         TCPConnection(ConnectionSecurity sec, streams_boost::asio::io_service& ioService, uint32_t blockSize, outFormat_t outFormat,
-                      DataHandler & dHandler,  InfoHandler & iHandler);
+                      DataHandler & dHandler,  InfoHandler & iHandler,
+                      const std::string & certificate,
+                      const std::string & key);
 
         /// Destructor
         ~TCPConnection();
@@ -96,6 +98,9 @@ namespace mcts
         // Blocksize
         uint32_t blockSize_;
 
+        // Prepended message size header
+        bool messageHeader_;
+
         // output format
         outFormat_t outFormat_;
 
@@ -105,12 +110,14 @@ namespace mcts
 
         bool isShutdown_;
 
-        static SocketPtr createConnection(ConnectionSecurity sec, streams_boost::asio::io_service& ioService)
+        static SocketPtr createConnection(ConnectionSecurity sec, streams_boost::asio::io_service& ioService, const std::string & certificate, const std::string & key)
         {
             if(sec == TLS) 
                 return SocketPtr(new Socket(ioService));
+            else if(key == "")
+                return SocketPtr(new TLSSocket(ioService, certificate));
             else
-                return SocketPtr(new TLSSocket(ioService));
+                return SocketPtr(new TLSSocket(ioService, certificate, key));
         }   
     };
     

--- a/com.ibm.streamsx.tcp/impl/include/mcts/server.h
+++ b/com.ibm.streamsx.tcp/impl/include/mcts/server.h
@@ -26,6 +26,11 @@
 
 namespace mcts 
 {
+    /// Set the profile of the server
+    /// CLIENT: Connections to specified address and port
+    /// SERVER: Listens on specified address and port
+    enum Role { CLIENT, SERVER };
+
 	typedef std::tr1::unordered_map<std::string, TCPConnectionWeakPtr> TCPConnectionWeakPtrMap;
 
     /// Class for multi-threaded TCP server
@@ -44,16 +49,15 @@ namespace mcts
         /// @param outFormat : line (condition to send data is "\n") or block (condition to send data is blockSize)
         /// @param handler that will process the data 
         /// @param handler that will send connection status infos
-        /// @param type of security to place on all connections (defaults to none)
+        /// @param secType type of security to place on all connections (defaults to none)
         TCPServer(std::string const & address, uint32_t port, 
                   std::size_t threadPoolSize, std::size_t maxConnections, std::size_t maxUnreadResponseCount,
                   uint32_t blockSize, outFormat_t outFormat, bool broadcastResponse, bool isDuplexConnection, bool makeConnReadOnly,
                   DataHandler::Handler dhandler, AsyncDataItem::Handler eHandler, InfoHandler::Handler iHandler, MetricsHandler::Handler mHandler,
-                  ConnectionSecurity secType = NONE);
+                  Role roleType = SERVER, ConnectionSecurity secType = NONE, const std::string & certificateFile = "", const std::string & privateKeyFile = "");
 
         /// Set the keep alive socket options
         void setKeepAlive(int32_t time, int32_t probes, int32_t interval);
-
 
         /// Run the server's io_service loop
         void run();
@@ -67,6 +71,9 @@ namespace mcts
 
         /// Create an acceptor
         void createAcceptor(std::string const & address, uint32_t port);
+
+        // Connect to another server
+        void connect(std::string const & address, uint32_t port);
 
         /// Add new connection to a map of connections
         void mapConnection(TCPConnectionPtr const & connPtr);
@@ -89,8 +96,18 @@ namespace mcts
         /// @param e the error code of the operation
         void handleAccept(TCPAcceptorPtr & acceptor, streams_boost::system::error_code const & e);
 
+        /// Handle the competion of an asynchronous connect operation
+        /// @param e the error code of the operation
+        void handleConnect(TCPConnectionPtr conn, streams_boost::system::error_code const & e);
+
+        /// The role of the sever, client (connects) or server (accepts)
+        Role roleType_;
+
         /// The security type employed on all connections
         ConnectionSecurity securityType_;
+        /// If utilized, the certifcate and private key path
+        const std::string & certificateFile_;
+        const std::string & privateKeyFile_;
         
         /// The number of threads that will call io_service::run()
         std::size_t threadPoolSize_;

--- a/com.ibm.streamsx.tcp/impl/include/mcts/socket.h
+++ b/com.ibm.streamsx.tcp/impl/include/mcts/socket.h
@@ -17,6 +17,8 @@ namespace mcts
   {
     public:
       typedef streams_boost::function<void(const streams_boost::system::error_code&, std::size_t)> async_complete_func;
+      typedef streams_boost::function<void(const streams_boost::system::error_code)> accept_complete_func;
+      typedef streams_boost::function<void(const streams_boost::system::error_code)> connect_complete_func;
 
       Socket(streams_boost::asio::io_service & ioService);
 
@@ -34,8 +36,8 @@ namespace mcts
       /// Status of socket
       bool isOpen() const { return socket_.is_open(); }
 
-      virtual void connect();
-      virtual void accept();
+      virtual void handleConnect(connect_complete_func handler, const streams_boost::system::error_code & ec);
+      virtual void handleAccept(accept_complete_func handler, const streams_boost::system::error_code & ec);
 
       /// Shuts down the socket, either send, receive, or both
       virtual void shutdown(streams_boost::asio::ip::tcp::socket::shutdown_type what, streams_boost::system::error_code & ec);

--- a/com.ibm.streamsx.tcp/impl/include/mcts/tls_socket.h
+++ b/com.ibm.streamsx.tcp/impl/include/mcts/tls_socket.h
@@ -18,10 +18,11 @@ namespace mcts
   class TLSSocket : public Socket
   {
   public:
-    TLSSocket(streams_boost::asio::io_service & ioService);
+    TLSSocket(streams_boost::asio::io_service & ioService, const std::string & certifcate);
+    TLSSocket(streams_boost::asio::io_service & ioService, const std::string & certifcate, const std::string & key);
 
-    virtual void connect();
-    virtual void accept();
+    virtual void handleConnect(connect_complete_func handler, const streams_boost::system::error_code & ec);
+    virtual void handleAccept(accept_complete_func handler, const streams_boost::system::error_code & ec);
     virtual void shutdown(streams_boost::asio::ip::tcp::socket::shutdown_type what, streams_boost::system::error_code & ec);
 
     virtual void async_write(streams_boost::asio::const_buffers_1 buffer, async_complete_func handler);

--- a/com.ibm.streamsx.tcp/impl/src/mcts/connection.cpp
+++ b/com.ibm.streamsx.tcp/impl/src/mcts/connection.cpp
@@ -21,8 +21,8 @@ namespace mcts
     uint32_t TCPConnection::numConnections_ = 0;
 
     TCPConnection::TCPConnection(ConnectionSecurity sec, streams_boost::asio::io_service & ioService, uint32_t blockSize, outFormat_t outFormat,
-    						DataHandler & dHandler, InfoHandler & iHandler)
-        : socket_(createConnection(sec, ioService)),
+    						DataHandler & dHandler, InfoHandler & iHandler, const std::string & certificate, const std::string & key)
+        : socket_(createConnection(sec, ioService, certificate, key)),
           dataHandler_(dHandler),
           infoHandler_(iHandler),
           remoteIp_(""), // initialize with empty string

--- a/com.ibm.streamsx.tcp/impl/src/mcts/socket.cpp
+++ b/com.ibm.streamsx.tcp/impl/src/mcts/socket.cpp
@@ -36,14 +36,14 @@ void Socket::async_read_some(streams_boost::asio::mutable_buffers_1 buffer, asyn
   socket_.async_read_some(buffer, handler);
 }
 
-void Socket::connect()
+void Socket::handleConnect(connect_complete_func handler, const streams_boost::system::error_code & ec)
 {
-
+  handler(ec);
 }
 
-void Socket::accept()
+void Socket::handleAccept(accept_complete_func handler, const streams_boost::system::error_code & ec)
 {
-
+  handler(ec);
 }
 
 void Socket::shutdown(streams_boost::asio::ip::tcp::socket::shutdown_type what, streams_boost::system::error_code & ec)


### PR DESCRIPTION
Added the ability to specify the certificate and private key files. Also added the ability to set the TCPServer to be a client and connect to the specified address instead of accepting connections.
